### PR TITLE
Improve Mark as Shared flow: prevent thoughts from disappearing, add …

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Thouty - Your thought companion</title>
     <meta name="description" content="Every thought you have is captured, acted on, and turned into something worth sharing." />
-    <script type="module" crossorigin src="/assets/index-CcAp7yHw.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-D0Ey-9sV.css">
+    <script type="module" crossorigin src="/assets/index-B2viqoPJ.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-B0GsTyOV.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -398,14 +398,8 @@ export const useGenieNotesStore = create<GenieNotesStore>()(
         
         try {
           // Use updateThought which handles optimistic updates properly
-          // Don't call loadThoughts() here - the optimistic update should be sufficient
-          // and calling loadThoughts() might cause a race condition
+          // The optimistic update is sufficient - no need to reload and cause flicker
           await get().updateThought(thoughtId, { sharePosts: updatedSharePosts });
-          
-          // Small delay then reload to ensure database has updated
-          setTimeout(async () => {
-            await get().loadThoughts();
-          }, 500);
         } catch (error) {
           console.error('[markAsShared] Error marking as shared:', error);
           // On error, reload to get correct state


### PR DESCRIPTION
…toast notifications, auto-switch filters

- Automatically switch to 'All' filter when marking as shared from 'Draft' filter to keep thought visible
- Add toast notification when marking/unmarking as shared with platform info
- Keep thought selected and scroll into view after marking as shared
- Update Share Toast 'Mark as shared' button to use improved flow
- Provide clear feedback to users about where their thoughts are